### PR TITLE
Add script to enable/disable (Postgres and Redis) service ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ If you get a mysterious error about containers not being started or some-such, t
 
      $ vagrant ssh -- bin/reset-containers
 
+## Connecting additional ports
+
+Additional ports 6379 (redis) and 15432 (db/postgresql) can be connected after running this:
+
+     $ vagrant ssh -- bin/turn-port db on
+     $ vagrant ssh -- bin/turn-port redis on
+
 ## Post build clean-up
 
 Once the VM is built, a few cleanup bits should be done:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.network :forwarded_port, guest:  5000, host:  5000, auto_correct: true, id: "musicbrainz"
+  config.vm.network :forwarded_port, guest:  6379, host:  6379, auto_correct: true, id: "redis"
   config.vm.network :forwarded_port, guest:  8080, host:  8080, auto_correct: true, id: "search"
   config.vm.network :forwarded_port, guest:  5432, host: 15432, auto_correct: true, id: "db"
 end

--- a/bin/turn-port
+++ b/bin/turn-port
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ "$#" != 2 ]] \
+    || ! (echo "$1" | grep -q -P '^(db|musicbrainz|redis|search)$') \
+    || ! (echo "$2" | grep -q -P '^(on|off)$'); then
+    echo "Usage: $0 <db|musicbrainz|redis|search> <on|off>" >&2
+    exit -1
+fi
+
+cd ~/musicbrainz/musicbrainz-docker
+
+if [ "$2" = "on" ]; then
+    if ! patch -p1 -f -s < ~/lib/turn-port/"$1"-on.diff &>/dev/null; then
+        echo "Service port '$1' in the VM has already been turned on!" >&2
+        exit -1
+    fi
+else
+    if ! patch -p1 -R -f -s < ~/lib/turn-port/"$1"-on.diff &>/dev/null; then
+        echo "Service port '$1' in the VM has already been turned off!" >&2
+        exit -1
+    fi
+fi
+
+docker-compose rm --stop "$1"
+docker-compose up --no-build -d

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,5 +6,7 @@ apt-get install -y docker.io docker-compose
 # copy the helper scripts from the musicbrainz-vm repo locally
 mkdir -p bin
 cp -r /vagrant/bin/* bin
+mkdir -p lib
+cp -r /vagrant/lib/* lib
 
 echo "Basic setup of the VM is complete. (bootstrap)"

--- a/lib/turn-port/db-on.diff
+++ b/lib/turn-port/db-on.diff
@@ -1,0 +1,11 @@
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -18,6 +18,8 @@ services:
+       - pgdata:/var/lib/postgresql/data
+     expose:
+       - "5432"
++    ports:
++      - "5432:5432"
+ 
+   musicbrainz:
+     build: musicbrainz-dockerfile

--- a/lib/turn-port/musicbrainz-on.diff
+++ b/lib/turn-port/musicbrainz-on.diff
@@ -1,0 +1,11 @@
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -21,6 +21,8 @@ services:
+ 
+   musicbrainz:
+     build: musicbrainz-dockerfile
++    ports:
++      - "5000:5000"
+     volumes:
+       - dbdump:/media/dbdump
+     restart: unless-stopped

--- a/lib/turn-port/redis-on.diff
+++ b/lib/turn-port/redis-on.diff
@@ -1,0 +1,8 @@
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -55,3 +55,5 @@ services:
+     restart: unless-stopped
+     expose:
+       - "6379"
++    ports:
++      - "6379:6379"

--- a/lib/turn-port/search-on.diff
+++ b/lib/turn-port/search-on.diff
@@ -1,0 +1,11 @@
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -45,6 +45,8 @@ services:
+   search:
+     build: search-dockerfile
+     restart: unless-stopped
++    ports:
++      - "8080:8080"
+     volumes:
+       - indexdata:/home/search/indexdata
+ 


### PR DESCRIPTION
This script allows to enable/disable forwarding docker service ports outside the VM. Allowed services are `db` (Postgres), `musicbrainz` (MBS), `redis` (Redis), and `search` (Lucene-based search server).

For example, the following command will expose Redis port 6379 (inside and) outside the VM:

```sh
vagrant ssh -- bin/turn-port redis on
```